### PR TITLE
Ensure consistent return from log_ai_function when logging disabled

### DIFF
--- a/ai_data_science_team/tools/logging.py
+++ b/ai_data_science_team/tools/logging.py
@@ -58,4 +58,6 @@ def log_ai_function(response: str, file_name: str, log: bool = True, log_path: s
         return (file_path, file_name)
     
     else:
-        return None
+        # Maintain a consistent return type even when logging is disabled
+        # so callers expecting a tuple of (path, file_name) do not fail
+        return (None, None)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+# Ensure the package is importable without installation
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from ai_data_science_team.tools.logging import log_ai_function
+
+def test_log_ai_function_returns_tuple_when_disabled(tmp_path):
+    result = log_ai_function("response", "file.txt", log=False, log_path=str(tmp_path))
+    assert result == (None, None)
+


### PR DESCRIPTION
## Summary
- fix log_ai_function to return a tuple even when logging is disabled
- add regression test for log_ai_function

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b81972f2c832489ceeb98b5054c9d